### PR TITLE
feat: slash command menu for chat inputs

### DIFF
--- a/app/components/chat/ChatInput.vue
+++ b/app/components/chat/ChatInput.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { Command } from '~/types'
+
 const props = defineProps<{
   modelValue: string;
   placeholder: string;
@@ -13,7 +15,29 @@ const emit = defineEmits<{
   stop: [];
 }>();
 
+const { commands: allCommands, fetchAll: fetchCommands } = useCommands()
+const { skills: allSkills, fetchAll: fetchSkills } = useSkills()
 const inputRef = ref<HTMLTextAreaElement | null>(null);
+
+// Command/Skill Menu State
+const isMenuOpen = ref(false)
+const selectedItemIdx = ref(0)
+const menuSearchQuery = ref('')
+
+const menuItems = computed(() => {
+  const items = [
+    ...allCommands.value.map(c => ({ type: 'command' as const, name: c.frontmatter.name, description: c.frontmatter.description, slug: c.slug, directory: c.directory })),
+    ...allSkills.value.map(s => ({ type: 'skill' as const, name: s.frontmatter.name, description: s.frontmatter.description, slug: s.slug }))
+  ]
+  
+  if (!menuSearchQuery.value) return items
+  
+  const q = menuSearchQuery.value.toLowerCase()
+  return items.filter(i => 
+    i.name.toLowerCase().includes(q) || 
+    i.description?.toLowerCase().includes(q)
+  )
+})
 
 function autoResize() {
   const el = inputRef.value;
@@ -22,12 +46,60 @@ function autoResize() {
   el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
 }
 
+function selectItem(item: { type: 'command' | 'skill'; name: string }) {
+  emit('update:modelValue', `/${item.name} `)
+  isMenuOpen.value = false
+  inputRef.value?.focus()
+}
+
 function handleKeydown(e: KeyboardEvent) {
+  // Command Menu Navigation
+  if (isMenuOpen.value && menuItems.value.length > 0) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      selectedItemIdx.value = (selectedItemIdx.value + 1) % menuItems.value.length
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      selectedItemIdx.value = (selectedItemIdx.value - 1 + menuItems.value.length) % menuItems.value.length
+      return
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      const item = menuItems.value[selectedItemIdx.value]
+      if (item) selectItem(item)
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      isMenuOpen.value = false
+      return
+    }
+  }
+
   if (e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
     emit("send");
   }
 }
+
+// Watch value changes to detect slash
+watch(() => props.modelValue, (newVal) => {
+  // Detect "/" at start
+  if (newVal.startsWith('/')) {
+    const query = newVal.slice(1).split(' ')[0] || ''
+    if (newVal.includes(' ')) {
+      isMenuOpen.value = false
+    } else {
+      menuSearchQuery.value = query
+      isMenuOpen.value = true
+      selectedItemIdx.value = 0
+    }
+  } else {
+    isMenuOpen.value = false
+  }
+})
 
 function focus() {
   inputRef.value?.focus();
@@ -37,11 +109,27 @@ function resetHeight() {
   if (inputRef.value) inputRef.value.style.height = "auto";
 }
 
+onMounted(async () => {
+  await Promise.all([
+    allCommands.value.length === 0 ? fetchCommands() : Promise.resolve(),
+    allSkills.value.length === 0 ? fetchSkills() : Promise.resolve()
+  ])
+})
+
 defineExpose({ focus, resetHeight });
 </script>
 
 <template>
-  <div class="shrink-0 px-5 pb-5 pt-2">
+  <div class="shrink-0 px-5 pb-5 pt-2 relative">
+    <!-- Command Menu -->
+    <ChatV2CommandMenu
+      :items="menuItems"
+      :selected-index="selectedItemIdx"
+      :is-open="isMenuOpen"
+      class="!bottom-[calc(100%-8px)] left-5 !w-[calc(100%-40px)]"
+      @select="selectItem"
+    />
+
     <div
       class="relative rounded-2xl transition-all duration-200"
       :style="{

--- a/app/components/cli/chatv2/ChatV2CommandMenu.vue
+++ b/app/components/cli/chatv2/ChatV2CommandMenu.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+interface MenuItem {
+  type: 'command' | 'skill'
+  name: string
+  description?: string
+  slug: string
+  directory?: string
+}
+
+const props = defineProps<{
+  items: MenuItem[]
+  selectedIndex: number
+  isOpen: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', item: MenuItem): void
+}>()
+
+const menuRef = ref<HTMLElement | null>(null)
+const selectedItemRef = ref<HTMLElement | null>(null)
+
+// Scroll selected item into view
+watch(() => props.selectedIndex, (newIdx) => {
+  if (newIdx >= 0) {
+    nextTick(() => {
+      selectedItemRef.value?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+    })
+  }
+})
+</script>
+
+<template>
+  <div
+    v-if="isOpen && items.length > 0"
+    ref="menuRef"
+    class="absolute bottom-full left-0 mb-2 w-full max-w-[400px] max-h-[300px] overflow-y-auto rounded-xl border shadow-xl z-50 flex flex-col"
+    style="background: var(--surface-raised); border-color: var(--border-subtle);"
+  >
+    <div class="p-1.5 space-y-0.5">
+      <button
+        v-for="(item, idx) in items"
+        :key="`${item.type}-${item.slug}`"
+        :ref="el => { if (idx === selectedIndex) selectedItemRef = (el as HTMLElement) }"
+        class="w-full flex flex-col items-start px-3 py-2 rounded-lg transition-all text-left group"
+        :class="idx === selectedIndex ? 'bg-[var(--accent-muted)]' : 'hover:bg-[var(--surface-hover)]'"
+        @click="emit('select', item)"
+      >
+        <div class="flex items-center gap-2 w-full">
+          <UIcon 
+            :name="item.type === 'command' ? 'i-lucide-terminal' : 'i-lucide-sparkles'" 
+            class="size-3.5 shrink-0" 
+            :style="{ color: idx === selectedIndex ? 'var(--accent)' : 'var(--text-tertiary)' }" 
+          />
+          <span class="font-mono text-[13px] font-semibold truncate" :style="{ color: idx === selectedIndex ? 'var(--text-primary)' : 'var(--text-secondary)' }">
+            /{{ item.name }}
+          </span>
+          <span v-if="item.type === 'skill'" class="text-[8px] font-bold uppercase tracking-wider px-1.5 py-px rounded bg-accent/10 text-accent ml-2">
+            Skill
+          </span>
+          <span v-if="item.directory" class="text-[9px] font-mono px-1.5 py-px rounded-full badge-subtle opacity-60 ml-auto">
+            {{ item.directory }}
+          </span>
+        </div>
+        <p v-if="item.description" class="text-[11px] mt-0.5 line-clamp-1 opacity-70 pl-5 text-tertiary">
+          {{ item.description }}
+        </p>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Custom scrollbar for the menu */
+div::-webkit-scrollbar {
+  width: 4px;
+}
+div::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 10px;
+}
+</style>

--- a/app/components/cli/chatv2/ChatV2Input.vue
+++ b/app/components/cli/chatv2/ChatV2Input.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { Command } from '~/types'
+
 const props = defineProps<{
   modelValue: string
   disabled?: boolean
@@ -14,8 +16,30 @@ const emit = defineEmits<{
   (e: 'blur'): void
 }>()
 
+const { commands: allCommands, fetchAll: fetchCommands } = useCommands()
+const { skills: allSkills, fetchAll: fetchSkills } = useSkills()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const isFocused = ref(false)
+
+// Command/Skill Menu State
+const isMenuOpen = ref(false)
+const selectedItemIdx = ref(0)
+const menuSearchQuery = ref('')
+
+const menuItems = computed(() => {
+  const items = [
+    ...allCommands.value.map(c => ({ type: 'command' as const, name: c.frontmatter.name, description: c.frontmatter.description, slug: c.slug, directory: c.directory })),
+    ...allSkills.value.map(s => ({ type: 'skill' as const, name: s.frontmatter.name, description: s.frontmatter.description, slug: s.slug }))
+  ]
+  
+  if (!menuSearchQuery.value) return items
+  
+  const q = menuSearchQuery.value.toLowerCase()
+  return items.filter(i => 
+    i.name.toLowerCase().includes(q) || 
+    i.description?.toLowerCase().includes(q)
+  )
+})
 
 // Local value for v-model
 const localValue = computed({
@@ -64,8 +88,39 @@ function autoResize() {
   textareaRef.value.style.height = `${newHeight}px`
 }
 
+function selectItem(item: { type: 'command' | 'skill'; name: string }) {
+  localValue.value = `/${item.name} `
+  isMenuOpen.value = false
+  textareaRef.value?.focus()
+}
+
 // Handle keydown
 function handleKeydown(e: KeyboardEvent) {
+  // Command Menu Navigation
+  if (isMenuOpen.value && menuItems.value.length > 0) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      selectedItemIdx.value = (selectedItemIdx.value + 1) % menuItems.value.length
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      selectedItemIdx.value = (selectedItemIdx.value - 1 + menuItems.value.length) % menuItems.value.length
+      return
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      const item = menuItems.value[selectedItemIdx.value]
+      if (item) selectItem(item)
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      isMenuOpen.value = false
+      return
+    }
+  }
+
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault()
     if (!props.disabled && (localValue.value.trim() || attachedImages.value.length > 0)) {
@@ -74,19 +129,45 @@ function handleKeydown(e: KeyboardEvent) {
   }
 }
 
-// Watch value changes to resize
-watch(localValue, () => {
+// Watch value changes to resize and detect slash
+watch(localValue, (newVal) => {
   nextTick(() => autoResize())
+
+  // Detect "/" at start
+  if (newVal.startsWith('/')) {
+    const query = newVal.slice(1).split(' ')[0] || ''
+    if (newVal.includes(' ')) {
+      isMenuOpen.value = false
+    } else {
+      menuSearchQuery.value = query
+      isMenuOpen.value = true
+      selectedItemIdx.value = 0
+    }
+  } else {
+    isMenuOpen.value = false
+  }
 })
 
 // Focus on mount
-onMounted(() => {
+onMounted(async () => {
   textareaRef.value?.focus()
+  await Promise.all([
+    allCommands.value.length === 0 ? fetchCommands() : Promise.resolve(),
+    allSkills.value.length === 0 ? fetchSkills() : Promise.resolve()
+  ])
 })
 </script>
 
 <template>
-  <div class="px-2 py-1.5 sm:px-3 sm:py-2" style="background: var(--surface-base);">
+  <div class="px-2 py-1.5 sm:px-3 sm:py-2 relative" style="background: var(--surface-base);">
+    <!-- Command Menu -->
+    <ChatV2CommandMenu
+      :items="menuItems"
+      :selected-index="selectedItemIdx"
+      :is-open="isMenuOpen"
+      @select="selectItem"
+    />
+
     <!-- Image Previews -->
     <div v-if="attachedImages.length > 0" class="flex gap-2 mb-2 overflow-x-auto pb-1">
       <div v-for="(img, idx) in attachedImages" :key="idx" class="relative group shrink-0">


### PR DESCRIPTION
## Summary

- Add a `/` slash command picker to both the legacy ChatInput and the ChatV2 input
- Typing `/` in either chat input opens a filtered command menu populated from the user's Claude commands

## Purpose

Users had no way to invoke their saved Claude commands from within the chat interface. This feature brings the slash command UX (familiar from Claude Code itself) into the web UI, letting users trigger commands directly while composing a message.

## Features Changed

- **`app/components/cli/chatv2/ChatV2CommandMenu.vue`** — New component: floating dropdown that lists available commands filtered by the text after `/`; keyboard-navigable (arrow keys + Enter) with mouse support; closes on Escape or outside click
- **`app/components/cli/chatv2/ChatV2Input.vue`** — Detects `/` prefix in textarea, fetches commands, shows `ChatV2CommandMenu`, and inserts the selected command's prompt text into the input on selection
- **`app/components/chat/ChatInput.vue`** — Same slash command integration added to the legacy chat input component

## Services Impacted

| Layer     | Files |
|-----------|-------|
| Frontend  | `ChatV2Input.vue`, `ChatInput.vue`, `ChatV2CommandMenu.vue` (new) |

## Tests Included

- [ ] Type `/` in ChatV2 input — command menu appears with all available commands
- [ ] Type `/foo` — menu filters to commands matching "foo"
- [ ] Press arrow keys — selection moves through the list
- [ ] Press Enter or click a command — command text is inserted into the input and menu closes
- [ ] Press Escape — menu closes without inserting anything
- [ ] Click outside the menu — menu closes
- [ ] Type `/` in legacy ChatInput — same picker behavior applies
- [ ] No commands match the filter — menu shows empty state (or closes)