### PR TITLE
feat: live context details recalculation after response completion

### DIFF
--- a/app/components/cli/chatv2/ChatV2ContextDetails.vue
+++ b/app/components/cli/chatv2/ChatV2ContextDetails.vue
@@ -96,6 +96,18 @@ const getStatusColor = () => {
       </div>
     </div>
 
+    <!-- Cost Section -->
+    <div v-if="metrics.cost.total > 0" class="space-y-3">
+      <h4 class="text-[11px] font-bold uppercase tracking-wider" style="color: var(--text-tertiary);">Session Cost</h4>
+      <div class="flex items-center justify-between p-2.5 rounded-lg" style="background: var(--surface-raised);">
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-dollar-sign" class="size-3.5" style="color: #22c55e;" />
+          <span class="text-[12px]" style="color: var(--text-primary);">Total Cost</span>
+        </div>
+        <span class="text-[14px] font-mono font-semibold" style="color: #22c55e;">${{ metrics.cost.total.toFixed(4) }}</span>
+      </div>
+    </div>
+
     <!-- Information Box -->
     <div class="p-3 rounded-xl border space-y-2" style="background: rgba(229, 169, 62, 0.05); border-color: rgba(229, 169, 62, 0.15);">
       <div class="flex items-center gap-2">

--- a/app/composables/useChatV2Handler.ts
+++ b/app/composables/useChatV2Handler.ts
@@ -259,16 +259,29 @@ export function useChatV2Handler() {
           sessionStore.setStatus(completeSessionId, 'idle')
           sessionStore.appendRealtime(completeSessionId, message)
 
-          // Update context monitor if usage info is available
-          if (message.metadata?.modelUsage) {
-            contextMonitor.handleWebSocketEvent({
-              type: 'token_update',
-              tokens: {
-                input: message.metadata.modelUsage.input_tokens || 0,
-                output: message.metadata.modelUsage.output_tokens || 0,
-                cached: message.metadata.modelUsage.cache_read_input_tokens || 0,
-              }
-            } as any)
+          // Update context monitor with aggregated usage from result
+          if (message.metadata?.aggregatedUsage) {
+            const usage = message.metadata.aggregatedUsage
+            contextMonitor.updateTokenUsage({
+              input: usage.input || 0,
+              output: usage.output || 0,
+              cacheRead: usage.cacheRead || 0,
+              cacheCreation: usage.cacheCreation || 0,
+            })
+
+            // Update context window total if provided
+            if (usage.contextWindow) {
+              contextMonitor.metrics.value.contextWindow.total = usage.contextWindow
+              // Recalculate percentage
+              const used = contextMonitor.metrics.value.contextWindow.used
+              contextMonitor.metrics.value.contextWindow.percentage =
+                Math.round((used / usage.contextWindow) * 10000) / 100
+            }
+
+            // Update cost if provided
+            if (usage.totalCost !== undefined) {
+              contextMonitor.metrics.value.cost.total = usage.totalCost
+            }
           }
         }
         break

--- a/server/utils/messageNormalizer.ts
+++ b/server/utils/messageNormalizer.ts
@@ -141,8 +141,36 @@ export function normalizeSDKMessage(
       // The accumulated stream_delta content will be finalized to text by the frontend
     }
 
-    // Add stop reason as complete message
-    if (sdkMessage.stop_reason) {
+    // Add complete message with full usage data
+    {
+      // Aggregate modelUsage across all models (Record<string, ModelUsage>)
+      let totalInput = 0
+      let totalOutput = 0
+      let totalCacheRead = 0
+      let totalCacheCreation = 0
+      let totalCost = sdkMessage.total_cost_usd || 0
+      let contextWindow = 200_000
+
+      if (sdkMessage.modelUsage && typeof sdkMessage.modelUsage === 'object') {
+        for (const modelUsage of Object.values(sdkMessage.modelUsage) as any[]) {
+          totalInput += modelUsage.inputTokens || 0
+          totalOutput += modelUsage.outputTokens || 0
+          totalCacheRead += modelUsage.cacheReadInputTokens || 0
+          totalCacheCreation += modelUsage.cacheCreationInputTokens || 0
+          if (modelUsage.contextWindow) {
+            contextWindow = modelUsage.contextWindow
+          }
+        }
+      }
+
+      // Also check top-level usage as fallback
+      if (totalInput === 0 && sdkMessage.usage) {
+        totalInput = sdkMessage.usage.input_tokens || 0
+        totalOutput = sdkMessage.usage.output_tokens || 0
+        totalCacheRead = sdkMessage.usage.cache_read_input_tokens || 0
+        totalCacheCreation = sdkMessage.usage.cache_creation_input_tokens || 0
+      }
+
       messages.push({
         kind: 'complete',
         id: randomUUID(),
@@ -152,6 +180,14 @@ export function normalizeSDKMessage(
         metadata: {
           stopReason: sdkMessage.stop_reason,
           modelUsage: sdkMessage.modelUsage,
+          aggregatedUsage: {
+            input: totalInput,
+            output: totalOutput,
+            cacheRead: totalCacheRead,
+            cacheCreation: totalCacheCreation,
+            contextWindow,
+            totalCost,
+          },
         },
       })
     }


### PR DESCRIPTION
## Summary

- Recalculate and display context details (token usage, context window %, cost) after each bot response completes
- Aggregate `modelUsage` from SDK result messages correctly (it's `Record<string, ModelUsage>`, not flat)
- Add session cost display to the Context Details panel

## Purpose

The context details panel was not updating after responses because the SDK's `result` message was being parsed incorrectly — `modelUsage` is a `Record<string, ModelUsage>` keyed by model name, but was treated as a flat object with `input_tokens`. Additionally, the `complete` event was gated on `stop_reason` being truthy, which skipped updates when it was `null`.

## Features Changed

- **`server/utils/messageNormalizer.ts`**: Always emit `complete` message on `result` type (not gated by `stop_reason`). Aggregate `modelUsage` across all models and include `aggregatedUsage` with input, output, cacheRead, cacheCreation, contextWindow, and totalCost.
- **`app/composables/useChatV2Handler.ts`**: Use `updateTokenUsage()` (absolute set) instead of incremental `token_update`. Update context window total from SDK's actual value. Set `cost.total` from `total_cost_usd`.
- **`app/components/cli/chatv2/ChatV2ContextDetails.vue`**: Add cost section showing session total when available.

## Services Impacted

| Layer | Files |
|-------|-------|
| Server API | `server/utils/messageNormalizer.ts` |
| Frontend | `app/composables/useChatV2Handler.ts`, `app/components/cli/chatv2/ChatV2ContextDetails.vue` |

## Tests Included

- [ ] Send a message in chat and verify the context circle updates percentage after response completes
- [ ] Open context details panel and verify token breakdown shows non-zero values
- [ ] Verify cost section appears when `total_cost_usd` is available
- [ ] Verify context window total reflects the model's actual context window size