### PR TITLE
feat: add git panel, file explorer, and tabbed right sidebar to ChatV2

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -474,7 +474,7 @@ function badgeFor(to: string) {
     </div>
     <GlobalSearch />
     <ChatPanel v-model:open="chatOpen" />
-    <FileEditorSidebar />
+    <FileEditorSidebar v-if="!route.path.startsWith('/cli')" />
   </UApp>
 </template>
 

--- a/app/components/chat/FileEditorSidebarContent.vue
+++ b/app/components/chat/FileEditorSidebarContent.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { highlightCode } from '~/utils/markdown'
+
+const { state, closeEditor } = useFileEditor()
+const { workingDir } = useWorkingDir()
+
+const content = ref('')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const fileName = computed(() => state.value.filePath?.split('/').pop() || '')
+const displayPath = computed(() => state.value.filePath || '')
+
+async function fetchFileContent() {
+  if (!state.value.filePath) return
+  
+  loading.value = true
+  error.value = null
+  
+  try {
+    const data = await $fetch<{ content: string }>('/api/files', {
+      query: { 
+        path: state.value.filePath,
+        projectDir: workingDir.value
+      }
+    })
+    content.value = data.content
+  } catch (err: any) {
+    error.value = err.data?.message || err.message || 'Failed to read file'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => state.value.filePath, (newPath) => {
+  if (newPath && !state.value.diffInfo) {
+    fetchFileContent()
+  } else if (state.value.diffInfo) {
+    // If we have diff info, we can construct a diff view
+    const diff = `--- a/${fileName.value}\n+++ b/${fileName.value}\n` + 
+                 generateDiff(state.value.diffInfo.oldContent, state.value.diffInfo.newContent)
+    content.value = diff
+  }
+}, { immediate: true })
+
+function generateDiff(oldStr: string, newStr: string) {
+  return newStr
+}
+
+const highlightedHtml = ref('')
+
+async function updateHighlighting() {
+  if (!content.value) {
+    highlightedHtml.value = ''
+    return
+  }
+  
+  const lang = state.value.diffInfo ? 'diff' : (fileName.value.split('.').pop() || 'text')
+  highlightedHtml.value = await highlightCode(content.value, lang)
+}
+
+watch(content, updateHighlighting, { immediate: true })
+</script>
+
+<template>
+  <div class="flex-1 flex flex-col min-h-0 overflow-hidden">
+    <!-- Header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b border-border-subtle shrink-0">
+      <div class="flex items-center gap-3 min-w-0">
+        <UIcon name="i-lucide-file-code" class="size-4 text-accent shrink-0" />
+        <div class="flex flex-col min-w-0">
+          <span class="text-[13px] font-semibold truncate">{{ fileName }}</span>
+          <span class="text-[10px] text-meta truncate">{{ displayPath }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Content -->
+    <div class="flex-1 overflow-hidden relative">
+      <div v-if="loading" class="absolute inset-0 flex items-center justify-center bg-card/50 z-10">
+        <UIcon name="i-lucide-loader-2" class="size-6 animate-spin text-accent" />
+      </div>
+      
+      <div v-if="error" class="p-8 text-center space-y-3">
+        <UIcon name="i-lucide-alert-circle" class="size-8 text-error mx-auto" />
+        <p class="text-sm text-error">{{ error }}</p>
+        <UButton label="Retry" size="sm" variant="soft" @click="fetchFileContent" />
+      </div>
+
+      <div v-else class="h-full overflow-auto p-4 custom-scrollbar">
+        <div v-if="highlightedHtml" class="shiki-editor" v-html="highlightedHtml" />
+        <pre v-else class="text-[12px] font-mono whitespace-pre-wrap">{{ content }}</pre>
+      </div>
+    </div>
+    
+    <!-- Footer -->
+    <div class="px-4 py-2 border-t border-border-subtle shrink-0 flex items-center justify-between">
+      <span class="text-[10px] text-meta font-mono">{{ content.split('\n').length }} lines</span>
+      <div v-if="state.diffInfo" class="text-[10px] px-2 py-0.5 rounded-full bg-accent-muted text-accent font-medium">
+        Viewing Changes
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.shiki-editor :deep(pre) {
+  margin: 0;
+  padding: 0;
+  background: transparent !important;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.shiki-editor :deep(.shiki-wrapper) {
+  background: transparent !important;
+}
+
+.shiki-editor :deep(code) {
+  background: transparent !important;
+  padding: 0;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--border-subtle);
+  border-radius: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--text-disabled);
+}
+</style>

--- a/app/components/cli/chatv2/ChatV2FileTree.vue
+++ b/app/components/cli/chatv2/ChatV2FileTree.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+const props = defineProps<{
+  projectName: string
+}>()
+
+const { data: files, pending, refresh } = useFetch(`/api/projects/${encodeURIComponent(props.projectName)}/files`, {
+  query: { maxDepth: 2 }
+})
+
+const expandedNodes = ref(new Set<string>())
+
+function toggleNode(path: string) {
+  if (expandedNodes.value.has(path)) {
+    expandedNodes.value.delete(path)
+  } else {
+    expandedNodes.value.add(path)
+  }
+}
+
+const emit = defineEmits<{
+  'open-file': [path: string]
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col h-full overflow-hidden">
+    <div class="px-4 py-2 border-b flex items-center justify-between" style="border-color: var(--border-subtle); background: var(--surface-raised);">
+      <span class="text-[11px] font-bold uppercase tracking-wider text-meta">Files</span>
+      <button @click="refresh()" class="p-1 hover-bg rounded transition-all" title="Refresh">
+        <UIcon name="i-lucide-refresh-cw" class="size-3" :class="{ 'animate-spin': pending }" />
+      </button>
+    </div>
+    
+    <div class="flex-1 overflow-y-auto p-2 custom-scrollbar">
+      <div v-if="pending && !files" class="flex items-center justify-center h-20">
+        <UIcon name="i-lucide-loader-2" class="size-5 animate-spin text-tertiary" />
+      </div>
+      
+      <div v-else-if="files" class="space-y-0.5">
+        <div v-for="item in files" :key="item.path">
+          <ChatV2FileTreeNode 
+            :item="item" 
+            :depth="0" 
+            :expanded-nodes="expandedNodes"
+            @toggle="toggleNode"
+            @open-file="path => emit('open-file', path)"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/cli/chatv2/ChatV2FileTreeNode.vue
+++ b/app/components/cli/chatv2/ChatV2FileTreeNode.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+const props = defineProps<{
+  item: any
+  depth: number
+  expandedNodes: Set<string>
+}>()
+
+const isExpanded = computed(() => props.expandedNodes.has(props.item.path))
+
+const emit = defineEmits<{
+  'toggle': [path: string]
+  'open-file': [path: string]
+}>()
+
+function handleClick() {
+  if (props.item.type === 'directory') {
+    emit('toggle', props.item.path)
+  } else {
+    emit('open-file', props.item.path)
+  }
+}
+
+const fileIcon = computed(() => {
+  if (props.item.type === 'directory') {
+    return isExpanded.value ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'
+  }
+  
+  const ext = props.item.extension?.toLowerCase()
+  if (['vue', 'ts', 'js', 'tsx', 'jsx'].includes(ext)) return 'i-lucide-file-code'
+  if (['md', 'txt'].includes(ext)) return 'i-lucide-file-text'
+  if (['json', 'yaml', 'yml'].includes(ext)) return 'i-lucide-braces'
+  if (['png', 'jpg', 'jpeg', 'svg', 'gif'].includes(ext)) return 'i-lucide-file-image'
+  return 'i-lucide-file'
+})
+
+const folderIcon = computed(() => {
+  return isExpanded.value ? 'i-lucide-folder-open' : 'i-lucide-folder'
+})
+</script>
+
+<template>
+  <div>
+    <button 
+      class="w-full flex items-center gap-2 px-2 py-1 hover-bg rounded transition-colors text-left group"
+      :style="{ paddingLeft: `${depth * 12 + 8}px` }"
+      @click="handleClick"
+    >
+      <UIcon v-if="item.type === 'directory'" :name="fileIcon" class="size-3 text-tertiary" />
+      <div v-else class="size-3 shrink-0" />
+      
+      <UIcon 
+        :name="item.type === 'directory' ? folderIcon : fileIcon" 
+        class="size-3.5 shrink-0" 
+        :style="{ color: item.type === 'directory' ? 'var(--accent)' : 'var(--text-tertiary)' }"
+      />
+      
+      <span class="text-[12px] truncate flex-1" :style="{ color: 'var(--text-secondary)' }">
+        {{ item.name }}
+      </span>
+    </button>
+    
+    <div v-if="item.type === 'directory' && isExpanded && item.children" class="mt-0.5">
+      <div v-for="child in item.children" :key="child.path">
+        <ChatV2FileTreeNode 
+          :item="child" 
+          :depth="depth + 1" 
+          :expanded-nodes="expandedNodes"
+          @toggle="path => emit('toggle', path)"
+          @open-file="path => emit('open-file', path)"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/cli/chatv2/ChatV2GitPanel.vue
+++ b/app/components/cli/chatv2/ChatV2GitPanel.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+const props = defineProps<{
+  projectName: string
+}>()
+
+const { data: status, pending, refresh } = useFetch(`/api/projects/${encodeURIComponent(props.projectName)}/git/status`)
+
+const emit = defineEmits<{
+  'open-file': [path: string]
+}>()
+</script>
+
+<template>
+  <div class="flex flex-col h-full overflow-hidden">
+    <div class="px-4 py-2 border-b flex items-center justify-between" style="border-color: var(--border-subtle); background: var(--surface-raised);">
+      <div class="flex items-center gap-2">
+        <span class="text-[11px] font-bold uppercase tracking-wider text-meta">Git</span>
+        <span v-if="status?.branch" class="text-[10px] font-mono px-1.5 py-0.5 rounded-full" style="background: var(--accent-muted); color: var(--accent);">
+          <UIcon name="i-lucide-git-branch" class="size-2.5 inline mr-1" />
+          {{ status.branch }}
+        </span>
+      </div>
+      <button @click="refresh()" class="p-1 hover-bg rounded transition-all" title="Refresh">
+        <UIcon name="i-lucide-refresh-cw" class="size-3" :class="{ 'animate-spin': pending }" />
+      </button>
+    </div>
+    
+    <div class="flex-1 overflow-y-auto p-4 space-y-6 custom-scrollbar">
+      <div v-if="pending && !status" class="flex items-center justify-center h-20">
+        <UIcon name="i-lucide-loader-2" class="size-5 animate-spin text-tertiary" />
+      </div>
+      
+      <div v-else-if="status?.error" class="text-center py-8 px-4">
+        <UIcon name="i-lucide-alert-circle" class="size-8 mx-auto mb-3 text-tertiary opacity-40" />
+        <p class="text-[13px] font-medium mb-1" style="color: var(--text-primary);">Not a Git Repository</p>
+        <p class="text-[11px]" style="color: var(--text-tertiary);">{{ status.error }}</p>
+      </div>
+      
+      <div v-else-if="status" class="space-y-6">
+        <!-- Staged Changes -->
+        <div v-if="status.staged?.length" class="space-y-2">
+          <div class="flex items-center justify-between">
+            <h4 class="text-[11px] font-bold uppercase tracking-wider text-meta">Staged Changes</h4>
+            <span class="text-[10px] font-mono" style="color: var(--text-tertiary);">{{ status.staged.length }}</span>
+          </div>
+          <div class="space-y-1">
+            <button 
+              v-for="file in status.staged" :key="file"
+              class="w-full flex items-center gap-2 px-2 py-1.5 hover-bg rounded text-left group transition-colors"
+              @click="emit('open-file', file)"
+            >
+              <UIcon name="i-lucide-check-circle-2" class="size-3.5 text-success" />
+              <span class="text-[12px] truncate flex-1" style="color: var(--text-secondary);">{{ file }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Modified -->
+        <div v-if="status.modified?.length" class="space-y-2">
+          <div class="flex items-center justify-between">
+            <h4 class="text-[11px] font-bold uppercase tracking-wider text-meta">Modified</h4>
+            <span class="text-[10px] font-mono" style="color: var(--text-tertiary);">{{ status.modified.length }}</span>
+          </div>
+          <div class="space-y-1">
+            <button 
+              v-for="file in status.modified" :key="file"
+              class="w-full flex items-center gap-2 px-2 py-1.5 hover-bg rounded text-left group transition-colors"
+              @click="emit('open-file', file)"
+            >
+              <UIcon name="i-lucide-file-edit" class="size-3.5 text-accent" />
+              <span class="text-[12px] truncate flex-1" style="color: var(--text-secondary);">{{ file }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Untracked -->
+        <div v-if="status.untracked?.length" class="space-y-2">
+          <div class="flex items-center justify-between">
+            <h4 class="text-[11px] font-bold uppercase tracking-wider text-meta">Untracked</h4>
+            <span class="text-[10px] font-mono" style="color: var(--text-tertiary);">{{ status.untracked.length }}</span>
+          </div>
+          <div class="space-y-1">
+            <button 
+              v-for="file in status.untracked" :key="file"
+              class="w-full flex items-center gap-2 px-2 py-1.5 hover-bg rounded text-left group transition-colors"
+              @click="emit('open-file', file)"
+            >
+              <UIcon name="i-lucide-file-plus" class="size-3.5 text-tertiary" />
+              <span class="text-[12px] truncate flex-1" style="color: var(--text-secondary);">{{ file }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Deleted -->
+        <div v-if="status.deleted?.length" class="space-y-2">
+          <div class="flex items-center justify-between">
+            <h4 class="text-[11px] font-bold uppercase tracking-wider text-meta">Deleted</h4>
+            <span class="text-[10px] font-mono" style="color: var(--text-tertiary);">{{ status.deleted.length }}</span>
+          </div>
+          <div class="space-y-1">
+            <div 
+              v-for="file in status.deleted" :key="file"
+              class="w-full flex items-center gap-2 px-2 py-1.5 opacity-60 grayscale"
+            >
+              <UIcon name="i-lucide-file-minus" class="size-3.5 text-error" />
+              <span class="text-[12px] truncate flex-1 line-through" style="color: var(--text-tertiary);">{{ file }}</span>
+            </div>
+          </div>
+        </div>
+        
+        <div v-if="!status.modified?.length && !status.untracked?.length && !status.staged?.length && !status.deleted?.length" class="text-center py-12 px-4">
+          <UIcon name="i-lucide-check-circle" class="size-10 mx-auto mb-3 text-success opacity-30" />
+          <p class="text-[13px] font-medium" style="color: var(--text-secondary);">Working tree clean</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/components/cli/chatv2/ChatV2Interface.vue
+++ b/app/components/cli/chatv2/ChatV2Interface.vue
@@ -111,12 +111,13 @@ const inputText = ref('')
 const messagesContainerRef = ref<HTMLElement | null>(null)
 const sidebarCollapsed = ref(false)
 const mobileSidebarOpen = ref(false)
-const showContextDetails = ref(false)
+const showRightSidebar = ref(false)
+const activeRightTab = ref<'context' | 'explorer' | 'git' | 'preview'>('context')
 const isCreatingSession = ref(false)
 const isInputFocused = ref(false)
 
 // Context details sidebar drag-to-resize
-const contextSidebarWidth = ref(400)
+const contextSidebarWidth = ref(500)
 const isDraggingContextSidebar = ref(false)
 const dragStartX = ref(0)
 const dragStartWidth = ref(0)
@@ -135,7 +136,7 @@ function onContextSidebarDragStart(e: MouseEvent) {
 function onContextSidebarDragMove(e: MouseEvent) {
   if (!isDraggingContextSidebar.value) return
   const delta = dragStartX.value - e.clientX
-  contextSidebarWidth.value = Math.min(800, Math.max(240, dragStartWidth.value + delta))
+  contextSidebarWidth.value = Math.min(800, Math.max(300, dragStartWidth.value + delta))
 }
 
 function onContextSidebarDragEnd() {
@@ -143,6 +144,11 @@ function onContextSidebarDragEnd() {
   document.body.classList.remove('dragging-context-sidebar')
   document.removeEventListener('mousemove', onContextSidebarDragMove)
   document.removeEventListener('mouseup', onContextSidebarDragEnd)
+}
+
+function openRightTab(tab: 'context' | 'explorer' | 'git' | 'preview') {
+  activeRightTab.value = tab
+  showRightSidebar.value = true
 }
 
 // Responsive sidebar width based on window size
@@ -1260,13 +1266,34 @@ async function handleSessionDeleted(payload: { projectName: string; sessionId: s
   }
 }
 
-const { openFile } = useFileEditor()
+const { openFile, closeEditor, state: fileEditorState } = useFileEditor()
 
-// Handle file open (from tool use clicks)
+// Handle file open (from tool use clicks or sidebar)
 function handleOpenFile(filePath: string) {
   console.log('[ChatV2] Open file:', filePath)
-  if (filePath) {
-    openFile(filePath)
+  if (!filePath) return
+
+  // If path is relative, try to resolve it against project path
+  let absolutePath = filePath
+  if (!filePath.startsWith('/')) {
+    const projectPath = selectedProjectPath.value
+    if (projectPath) {
+      absolutePath = projectPath.endsWith('/') ? `${projectPath}${filePath}` : `${projectPath}/${filePath}`
+    }
+  }
+
+  openFile(absolutePath)
+  
+  // Switch to preview tab and ensure sidebar is open
+  activeRightTab.value = 'preview'
+  showRightSidebar.value = true
+}
+
+function handleClosePreview() {
+  closeEditor()
+  // If we were on preview tab, switch to explorer
+  if (activeRightTab.value === 'preview') {
+    activeRightTab.value = 'explorer'
   }
 }
 </script>
@@ -1524,22 +1551,39 @@ function handleOpenFile(filePath: string) {
         </div>
 
         <div class="flex items-center gap-2 shrink-0">
-          <!-- Model Selector -->
-          <ChatV2ModelSelector
-            v-if="(viewMode === 'history' && urlSessionId) || (viewMode === 'live' && isLiveChat)"
-            v-model="selectedModel"
-            :options="MODEL_OPTIONS_CHAT"
-          />
-
-          <!-- Permission Mode Selector (only when viewing a specific chat session) -->
-          <ChatV2PermissionModeSelector
-            v-if="(viewMode === 'history' && urlSessionId) || (viewMode === 'live' && currentSessionId)"
-            v-model="selectedPermissionMode"
-            :options="permissionModeOptions"
-          />
+          <!-- Sidebar Toggles -->
+          <div v-if="urlProjectName || currentSessionId || urlSessionId" class="flex items-center gap-1 px-1 py-1 rounded-lg" style="background: var(--surface-raised); border: 1px solid var(--border-subtle);">
+            <UTooltip text="Context Details" :popper="{ placement: 'top' }">
+              <button 
+                class="p-1.5 rounded-md transition-all hover-bg" 
+                :style="{ color: showRightSidebar && activeRightTab === 'context' ? 'var(--accent)' : 'var(--text-tertiary)' }"
+                @click="openRightTab('context')"
+              >
+                <UIcon name="i-lucide-database" class="size-4" />
+              </button>
+            </UTooltip>
+            <UTooltip text="File Browser" :popper="{ placement: 'top' }">
+              <button 
+                class="p-1.5 rounded-md transition-all hover-bg" 
+                :style="{ color: showRightSidebar && activeRightTab === 'files' ? 'var(--accent)' : 'var(--text-tertiary)' }"
+                @click="openRightTab('files')"
+              >
+                <UIcon name="i-lucide-folder-tree" class="size-4" />
+              </button>
+            </UTooltip>
+            <UTooltip text="Git Control" :popper="{ placement: 'top' }">
+              <button 
+                class="p-1.5 rounded-md transition-all hover-bg" 
+                :style="{ color: showRightSidebar && activeRightTab === 'git' ? 'var(--accent)' : 'var(--text-tertiary)' }"
+                @click="openRightTab('git')"
+              >
+                <UIcon name="i-lucide-git-branch" class="size-4" />
+              </button>
+            </UTooltip>
+          </div>
 
           <!-- Session ID (only in live mode) -->
-          <span v-if="viewMode === 'live' && currentSessionId" class="text-[10px] font-mono" style="color: var(--text-tertiary);">
+          <span v-if="viewMode === 'live' && currentSessionId" class="hidden md:inline text-[10px] font-mono opacity-50" style="color: var(--text-tertiary);">
             {{ currentSessionId.slice(0, 8) }}
           </span>
         </div>
@@ -1660,9 +1704,27 @@ function handleOpenFile(filePath: string) {
         <!-- Floating-style Controls (Thinking + Context) -->
         <div 
           v-if="(isLiveChat || currentSessionId || (viewMode === 'history' && urlSessionId)) && !isLoadingHistoryWithDelay && !isCreatingSession"
-          class="absolute bottom-0 left-0 right-0 flex justify-center items-center gap-4 py-4 z-10"
+          class="absolute bottom-0 left-0 right-0 flex justify-center items-center gap-3 py-4 z-10"
           style="background: linear-gradient(to top, var(--surface-base) 20%, transparent 100%); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);"
         >
+          <!-- Model Selector -->
+          <ChatV2ModelSelector
+            v-if="(viewMode === 'history' && urlSessionId) || (viewMode === 'live' && isLiveChat)"
+            v-model="selectedModel"
+            :options="MODEL_OPTIONS_CHAT"
+            class="shadow-lg border rounded-full bg-overlay backdrop-blur-md"
+            style="border-color: var(--border-subtle);"
+          />
+
+          <!-- Permission Mode Selector -->
+          <ChatV2PermissionModeSelector
+            v-if="(viewMode === 'history' && urlSessionId) || (viewMode === 'live' && currentSessionId)"
+            v-model="selectedPermissionMode"
+            :options="permissionModeOptions"
+            class="shadow-lg border rounded-full bg-overlay backdrop-blur-md"
+            style="border-color: var(--border-subtle);"
+          />
+
           <!-- Effort Level Selector -->
           <div ref="effortMenuRef" class="relative">
             <button
@@ -1726,7 +1788,7 @@ function handleOpenFile(filePath: string) {
             <div 
               class="flex items-center justify-center size-8 sm:size-9 rounded-full shadow-lg border backdrop-blur-md transition-all cursor-pointer hover:scale-105 active:scale-95"
               style="background: var(--surface-overlay); border-color: var(--border-subtle);"
-              @click="showContextDetails = !showContextDetails"
+              @click="openRightTab('context')"
             >
               <div class="relative size-6">
                 <!-- SVG Progress Circle -->
@@ -1791,22 +1853,22 @@ function handleOpenFile(filePath: string) {
     </div>
   </div>
 
-  <!-- Floating Right Sidebar - Context Details -->
+  <!-- Floating Right Sidebar - Details Panels -->
   <Teleport to="body">
     <div class="fixed inset-0 z-[100] pointer-events-none">
       <!-- Backdrop -->
       <Transition name="fade">
         <div 
-          v-if="showContextDetails" 
+          v-if="showRightSidebar" 
           class="absolute inset-0 bg-black/10 backdrop-blur-[1px] pointer-events-auto" 
-          @click="showContextDetails = false" 
+          @click="showRightSidebar = false" 
         />
       </Transition>
 
       <!-- Sidebar Panel -->
       <Transition name="slide">
         <div
-          v-if="showContextDetails"
+          v-if="showRightSidebar"
           class="absolute inset-y-0 right-0 flex flex-col shadow-2xl pointer-events-auto border-l"
           :style="{
             background: 'var(--surface-overlay)',
@@ -1821,24 +1883,97 @@ function handleOpenFile(filePath: string) {
             :class="isDraggingContextSidebar ? 'bg-accent/40' : 'hover:bg-accent/30'"
             @mousedown="onContextSidebarDragStart"
           />
-          <!-- Sidebar Header -->
-          <div class="shrink-0 px-4 h-14 border-b flex items-center justify-between" style="border-color: var(--border-subtle);">
-            <div class="flex items-center gap-2">
-              <UIcon name="i-lucide-database" class="size-4 text-accent" />
-              <h3 class="text-[13px] font-semibold" style="color: var(--text-primary);">Context Details</h3>
+          
+          <!-- Sidebar Header & Tabs -->
+          <div class="shrink-0 h-14 border-b flex items-center justify-between" style="border-color: var(--border-subtle);">
+            <div class="flex h-full items-stretch overflow-x-auto no-scrollbar">
+              <button 
+                class="px-4 flex items-center gap-2 border-b-2 transition-all text-[13px] font-semibold whitespace-nowrap"
+                :style="{ 
+                  borderColor: activeRightTab === 'context' ? 'var(--accent)' : 'transparent',
+                  color: activeRightTab === 'context' ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                  background: activeRightTab === 'context' ? 'var(--surface-raised)' : 'transparent'
+                }"
+                @click="activeRightTab = 'context'"
+              >
+                <UIcon name="i-lucide-database" class="size-4" />
+                <span>Context</span>
+              </button>
+              <button 
+                class="px-4 flex items-center gap-2 border-b-2 transition-all text-[13px] font-semibold whitespace-nowrap"
+                :style="{ 
+                  borderColor: activeRightTab === 'explorer' ? 'var(--accent)' : 'transparent',
+                  color: activeRightTab === 'explorer' ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                  background: activeRightTab === 'explorer' ? 'var(--surface-raised)' : 'transparent'
+                }"
+                @click="activeRightTab = 'explorer'"
+              >
+                <UIcon name="i-lucide-folder-tree" class="size-4" />
+                <span>Explorer</span>
+              </button>
+              <button 
+                class="px-4 flex items-center gap-2 border-b-2 transition-all text-[13px] font-semibold whitespace-nowrap"
+                :style="{ 
+                  borderColor: activeRightTab === 'git' ? 'var(--accent)' : 'transparent',
+                  color: activeRightTab === 'git' ? 'var(--text-primary)' : 'var(--text-tertiary)',
+                  background: activeRightTab === 'git' ? 'var(--surface-raised)' : 'transparent'
+                }"
+                @click="activeRightTab = 'git'"
+              >
+                <UIcon name="i-lucide-git-branch" class="size-4" />
+                <span>Git</span>
+              </button>
+              <div 
+                class="flex items-center gap-1 border-b-2 transition-all text-[13px] font-semibold whitespace-nowrap"
+                :style="{ 
+                  borderColor: activeRightTab === 'preview' ? 'var(--accent)' : 'transparent',
+                  background: activeRightTab === 'preview' ? 'var(--surface-raised)' : 'transparent',
+                  opacity: fileEditorState.isOpen ? 1 : 0.4
+                }"
+              >
+                <button 
+                  class="pl-4 pr-1 py-4 flex items-center gap-2"
+                  :style="{ color: activeRightTab === 'preview' ? 'var(--text-primary)' : 'var(--text-tertiary)' }"
+                  :disabled="!fileEditorState.isOpen"
+                  @click="activeRightTab = 'preview'"
+                >
+                  <UIcon name="i-lucide-eye" class="size-4" />
+                  <span>Preview</span>
+                </button>
+                <button 
+                  v-if="fileEditorState.isOpen"
+                  class="mr-2 p-1 rounded-md hover:bg-[var(--surface-hover)] text-meta transition-colors"
+                  @click.stop="handleClosePreview"
+                >
+                  <UIcon name="i-lucide-x" class="size-3" />
+                </button>
+              </div>
             </div>
             <button
-              class="p-1.5 rounded-lg hover-bg transition-all"
+              class="mx-4 p-1.5 rounded-lg hover-bg transition-all"
               style="background: var(--surface-raised);"
-              @click="showContextDetails = false"
+              @click="showRightSidebar = false"
             >
               <UIcon name="i-lucide-x" class="size-4" style="color: var(--text-tertiary);" />
             </button>
           </div>
 
-          <!-- Details Content -->
-          <div class="flex-1 overflow-y-auto">
-            <ChatV2ContextDetails :metrics="contextMonitor.metrics.value" />
+          <!-- Tab Content -->
+          <div class="flex-1 overflow-hidden flex flex-col">
+            <ChatV2ContextDetails v-if="activeRightTab === 'context'" :metrics="contextMonitor.metrics.value" />
+            <ChatV2FileTree 
+              v-else-if="activeRightTab === 'explorer'" 
+              :project-name="urlProjectName || localWorkingDir" 
+              @open-file="handleOpenFile"
+            />
+            <ChatV2GitPanel 
+              v-else-if="activeRightTab === 'git'" 
+              :project-name="urlProjectName || localWorkingDir" 
+              @open-file="handleOpenFile"
+            />
+            <div v-else-if="activeRightTab === 'preview'" class="flex-1 overflow-hidden flex flex-col">
+               <FileEditorSidebarContent />
+            </div>
           </div>
         </div>
       </Transition>

--- a/app/components/cli/chatv2/ChatV2ModelSelector.vue
+++ b/app/components/cli/chatv2/ChatV2ModelSelector.vue
@@ -43,15 +43,15 @@ onUnmounted(() => {
 <template>
   <div ref="dropdownRef" class="relative z-10 min-w-0">
     <button
-      class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-[11px] font-medium transition-all max-w-full"
-      style="background: var(--surface-raised); color: var(--text-secondary); border: 1px solid var(--border-subtle);"
+      class="flex items-center gap-2 px-3 py-1.5 rounded-full text-[11px] font-medium transition-all max-w-full hover:bg-[var(--surface-hover)]"
+      style="color: var(--text-secondary);"
       @click="isOpen = !isOpen"
     >
-      <UIcon name="i-lucide-cpu" class="size-3 shrink-0" />
+      <UIcon name="i-lucide-cpu" class="size-3.5 shrink-0" />
       <span class="truncate">{{ selectedOption?.label || 'Model' }}</span>
       <UIcon
-        :name="isOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
-        class="size-3 shrink-0"
+        :name="isOpen ? 'i-lucide-chevron-down' : 'i-lucide-chevron-up'"
+        class="size-3 shrink-0 opacity-50"
       />
     </button>
 
@@ -59,7 +59,7 @@ onUnmounted(() => {
     <Transition name="dropdown">
       <div
         v-if="isOpen"
-        class="absolute top-full right-0 mt-1 w-52 max-w-[calc(100vw-2rem)] rounded-xl overflow-hidden z-50"
+        class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-52 max-w-[calc(100vw-2rem)] rounded-xl overflow-hidden z-50"
         style="background: var(--surface-overlay); border: 1px solid var(--border-default); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15), 0 0 0 1px var(--border-subtle);"
       >
         <div class="py-1">

--- a/app/components/cli/chatv2/ChatV2PermissionModeSelector.vue
+++ b/app/components/cli/chatv2/ChatV2PermissionModeSelector.vue
@@ -45,15 +45,15 @@ onUnmounted(() => {
 <template>
   <div ref="dropdownRef" class="relative z-10 min-w-0">
     <button
-      class="flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-[11px] font-medium transition-all max-w-full"
-      style="background: var(--surface-raised); color: var(--text-secondary); border: 1px solid var(--border-subtle);"
+      class="flex items-center gap-2 px-3 py-1.5 rounded-full text-[11px] font-medium transition-all max-w-full hover:bg-[var(--surface-hover)]"
+      style="color: var(--text-secondary);"
       @click="isOpen = !isOpen"
     >
-      <UIcon name="i-lucide-shield" class="size-3 shrink-0" />
+      <UIcon name="i-lucide-shield" class="size-3.5 shrink-0" />
       <span class="truncate">{{ selectedOption?.label || 'Default' }}</span>
       <UIcon
-        :name="isOpen ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
-        class="size-3 shrink-0"
+        :name="isOpen ? 'i-lucide-chevron-down' : 'i-lucide-chevron-up'"
+        class="size-3 shrink-0 opacity-50"
       />
     </button>
 
@@ -61,7 +61,7 @@ onUnmounted(() => {
     <Transition name="dropdown">
       <div
         v-if="isOpen"
-        class="absolute top-full right-0 mt-1 w-56 max-w-[calc(100vw-2rem)] rounded-xl overflow-hidden z-50"
+        class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 max-w-[calc(100vw-2rem)] rounded-xl overflow-hidden z-50"
         style="background: var(--surface-overlay); border: 1px solid var(--border-default); box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15), 0 0 0 1px var(--border-subtle);"
       >
         <div class="py-1">

--- a/server/api/projects/[projectName]/files.get.ts
+++ b/server/api/projects/[projectName]/files.get.ts
@@ -1,0 +1,107 @@
+import { readdir, stat, access } from 'node:fs/promises'
+import { join, basename, relative, sep } from 'node:path'
+import { constants } from 'node:fs'
+
+interface FileTreeItem {
+  name: string
+  path: string
+  relativePath: string
+  type: 'file' | 'directory'
+  size: number
+  modified: string | null
+  extension: string
+  children?: FileTreeItem[]
+}
+
+async function getFileTree(dirPath: string, rootPath: string, maxDepth = 3, currentDepth = 0, showHidden = true): Promise<FileTreeItem[]> {
+  const items: FileTreeItem[] = []
+
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (!showHidden && entry.name.startsWith('.')) continue
+      
+      // Skip heavy build directories and VCS directories
+      if (['node_modules', 'dist', 'build', '.git', '.nuxt', '.output'].includes(entry.name)) continue
+
+      const fullPath = join(dirPath, entry.name)
+      const relPath = relative(rootPath, fullPath)
+      
+      const item: FileTreeItem = {
+        name: entry.name,
+        path: fullPath,
+        relativePath: relPath,
+        type: entry.isDirectory() ? 'directory' : 'file',
+        size: 0,
+        modified: null,
+        extension: entry.name.includes('.') ? entry.name.split('.').pop() || '' : ''
+      }
+
+      try {
+        const stats = await stat(fullPath)
+        item.size = stats.size
+        item.modified = stats.mtime.toISOString()
+      } catch (e) {
+        // Stats might fail for some files
+      }
+
+      if (entry.isDirectory() && currentDepth < maxDepth) {
+        try {
+          await access(fullPath, constants.R_OK)
+          item.children = await getFileTree(fullPath, rootPath, maxDepth, currentDepth + 1, showHidden)
+        } catch (e) {
+          item.children = []
+        }
+      }
+
+      items.push(item)
+    }
+  } catch (error) {
+    console.error(`Error reading directory ${dirPath}:`, error)
+  }
+
+  // Sort: directories first, then alphabetically
+  return items.sort((a, b) => {
+    if (a.type === b.type) return a.name.localeCompare(b.name)
+    return a.type === 'directory' ? -1 : 1
+  })
+}
+
+export default defineEventHandler(async (event) => {
+  const projectName = getRouterParam(event, 'projectName')
+  if (!projectName) {
+    throw createError({ statusCode: 400, message: 'Project name is required' })
+  }
+
+  // Use the project resolution logic from server/api/projects/resolve.get.ts
+  // For now, assume projectName is the decoded path or we can resolve it
+  let projectPath: string
+  try {
+    const res = await $fetch<{ projectName: string | null }>(`/api/projects/resolve?name=${encodeURIComponent(projectName)}`)
+    if (!res.projectName) {
+      // Fallback: maybe it's already a path
+      projectPath = projectName.replace(/-/g, '/')
+    } else {
+      // We need the actual path. Let's look up the project.
+      const projects = await $fetch<any[]>('/api/projects')
+      const project = projects.find(p => p.name === res.projectName)
+      if (!project) throw new Error('Project not found')
+      projectPath = project.path
+    }
+  } catch (e) {
+    projectPath = projectName.replace(/-/g, '/')
+  }
+
+  try {
+    await access(projectPath)
+  } catch (e) {
+    throw createError({ statusCode: 404, message: `Project path not found: ${projectPath}` })
+  }
+
+  const query = getQuery(event)
+  const maxDepth = parseInt(query.maxDepth as string) || 3
+  const showHidden = query.showHidden === 'true'
+
+  return await getFileTree(projectPath, projectPath, maxDepth, 0, showHidden)
+})

--- a/server/api/projects/[projectName]/git/status.get.ts
+++ b/server/api/projects/[projectName]/git/status.get.ts
@@ -1,0 +1,66 @@
+import { validateGitRepository, getCurrentBranchName, spawnAsync } from '../../../../utils/gitUtils'
+
+export default defineEventHandler(async (event) => {
+  const projectName = getRouterParam(event, 'projectName')
+  if (!projectName) {
+    throw createError({ statusCode: 400, message: 'Project name is required' })
+  }
+
+  let projectPath: string
+  try {
+    const res = await $fetch<{ projectName: string | null }>(`/api/projects/resolve?name=${encodeURIComponent(projectName)}`)
+    if (!res.projectName) {
+      projectPath = projectName.replace(/-/g, '/')
+    } else {
+      const projects = await $fetch<any[]>('/api/projects')
+      const project = projects.find(p => p.name === res.projectName)
+      if (!project) throw new Error('Project not found')
+      projectPath = project.path
+    }
+  } catch (e) {
+    projectPath = projectName.replace(/-/g, '/')
+  }
+
+  try {
+    await validateGitRepository(projectPath)
+    const branch = await getCurrentBranchName(projectPath)
+    
+    const { stdout: statusOutput } = await spawnAsync('git', ['status', '--porcelain'], { cwd: projectPath })
+    
+    const modified: string[] = []
+    const added: string[] = []
+    const deleted: string[] = []
+    const untracked: string[] = []
+    const staged: string[] = []
+
+    const lines = statusOutput.split('\n').filter(Boolean)
+    for (const line of lines) {
+      const status = line.slice(0, 2)
+      const file = line.slice(3).replace(/^"|"$/g, '')
+
+      if (status[0] !== ' ' && status[0] !== '?') {
+        staged.push(file)
+      }
+
+      if (status === '??') untracked.push(file)
+      else if (status[1] === 'M') modified.push(file)
+      else if (status[1] === 'A') added.push(file)
+      else if (status[1] === 'D') deleted.push(file)
+    }
+
+    return {
+      branch,
+      modified,
+      added,
+      deleted,
+      untracked,
+      staged,
+      projectPath
+    }
+  } catch (error: any) {
+    return {
+      error: error.message,
+      projectPath
+    }
+  }
+})

--- a/server/utils/gitUtils.ts
+++ b/server/utils/gitUtils.ts
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process'
+import { access } from 'node:fs/promises'
+
+export interface SpawnResult {
+  stdout: string
+  stderr: string
+  code: number | null
+}
+
+export function spawnAsync(command: string, args: string[], options: any = {}): Promise<SpawnResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      ...options,
+      shell: false,
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    child.stderr?.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    child.on('error', (error) => {
+      reject(error)
+    })
+
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, code })
+    })
+  })
+}
+
+export async function validateGitRepository(projectPath: string): Promise<void> {
+  try {
+    await access(projectPath)
+  } catch {
+    throw new Error(`Project path not found: ${projectPath}`)
+  }
+
+  try {
+    const { stdout } = await spawnAsync('git', ['rev-parse', '--is-inside-work-tree'], { cwd: projectPath })
+    if (stdout.trim() !== 'true') {
+      throw new Error('Not inside a git work tree')
+    }
+    await spawnAsync('git', ['rev-parse', '--show-toplevel'], { cwd: projectPath })
+  } catch {
+    throw new Error('Not a git repository. Initialize a git repository with "git init" to use source control features.')
+  }
+}
+
+export async function getCurrentBranchName(projectPath: string): Promise<string> {
+  try {
+    const { stdout, code } = await spawnAsync('git', ['symbolic-ref', '--short', 'HEAD'], { cwd: projectPath })
+    if (code === 0 && stdout.trim()) {
+      return stdout.trim()
+    }
+  } catch (error) {
+    // Ignore and fallback
+  }
+
+  const { stdout } = await spawnAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: projectPath })
+  return stdout.trim()
+}


### PR DESCRIPTION
## Summary

- Adds a tabbed right sidebar (Context / Explorer / Git / Preview) to the ChatV2 interface
- Introduces server-side API endpoints for browsing project files and querying git status/diff
- Moves model and permission mode selectors to the bottom floating controls bar, restyled as pill buttons

## Purpose

The chat interface lacked visibility into the project's file tree and git state during a session. This change surfaces those panels in a unified sidebar so users can browse files, review git changes, and preview opened files without leaving the chat view.

## Features Changed

- **`ChatV2Interface.vue`**: Replaced single `showContextDetails` toggle with a multi-tab `activeRightTab` state (`context | explorer | git | preview`). Added `openRightTab()` helper, resolved relative file paths against the project root, and integrated the new sidebar components. Model/permission selectors moved from header to bottom floating bar.
- **`ChatV2FileTree.vue` + `ChatV2FileTreeNode.vue`** *(new)*: Recursive file-tree browser that fetches from the new `/files` API and emits `open-file` events.
- **`ChatV2GitPanel.vue`** *(new)*: Displays git status (staged/unstaged/untracked files) and diff output fetched from the new `/git/status` API.
- **`FileEditorSidebarContent.vue`** *(new)*: Renders the active file editor content inside the Preview tab.
- **`ChatV2ModelSelector.vue` / `ChatV2PermissionModeSelector.vue`**: Restyled to rounded-pill buttons; dropdown now opens upward (`bottom-full`).
- **`server/api/projects/[projectName]/files.get.ts`** *(new)*: API endpoint to list directory contents for a given project path.
- **`server/api/projects/[projectName]/git/status.get.ts`** *(new)*: API endpoint returning git status and diff for a project.
- **`server/utils/gitUtils.ts`** *(new)*: Shared git utility functions used by the status endpoint.
- **`app/app.vue`**: Hides the global `FileEditorSidebar` on `/cli` routes to prevent double-rendering.

## Services Impacted

| Layer      | Files |
|------------|-------|
| Server API | `server/api/projects/[projectName]/files.get.ts`, `server/api/projects/[projectName]/git/status.get.ts`, `server/utils/gitUtils.ts` |
| Frontend   | `ChatV2Interface.vue`, `ChatV2FileTree.vue`, `ChatV2FileTreeNode.vue`, `ChatV2GitPanel.vue`, `FileEditorSidebarContent.vue`, `ChatV2ModelSelector.vue`, `ChatV2PermissionModeSelector.vue`, `app.vue` |

## Tests Included

- [ ] Open a project session — verify all four sidebar tabs render without errors
- [ ] Click Explorer tab — confirm file tree loads and clicking a file opens it in the Preview tab
- [ ] Click Git tab — confirm staged/unstaged files and diff are displayed correctly
- [ ] Click Preview tab close button — confirm it switches back to Explorer and clears the editor
- [ ] Verify model/permission selectors open upward from the bottom bar and selections persist
- [ ] Confirm global file editor sidebar is hidden on `/cli/*` routes