### PR TITLE
chore: standardize port to 3030 and fix chat message deduplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ agents-ui is a Nuxt 3-based visual dashboard for managing Claude Code agents, co
 
 ```bash
 # Development
-bun run dev          # Start dev server at http://localhost:3000
+bun run dev          # Start dev server at http://localhost:3030
 npm run dev          # Alternative with npm
 
 # Build & Production

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Thank you for your interest in contributing to **claude-code-agents-ui**! We’r
 4. **Open the app**
 
    ```
-   http://localhost:3000
+   http://localhost:3030
    ```
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ COPY --from=build /app/node_modules/node-pty/build /app/.output/server/node_modu
 
 # Set environment variables
 ENV HOST=0.0.0.0
-ENV PORT=3000
+ENV PORT=3030
 ENV NODE_ENV=production
 
-EXPOSE 3000
+EXPOSE 3030
 
 # Run the production server
 CMD ["node", ".output/server/index.mjs"]

--- a/app/components/cli/chatv2/ChatV2Interface.vue
+++ b/app/components/cli/chatv2/ChatV2Interface.vue
@@ -489,40 +489,85 @@ const displayMessages = computed<DisplayChatMessage[]>(() => {
   // Determine which session ID to use for live messages
   const liveSessionId = currentSessionId.value || urlSessionId.value
 
+  let merged: DisplayChatMessage[] = []
+
   // If viewing Claude Code history
   if (viewMode.value === 'history') {
     const historyMessages = convertClaudeCodeMessages(claudeCodeMessages.value)
 
     // If we have history messages and NOT continuing, just return history
     if (historyMessages.length > 0 && !isContinuingHistory.value) {
-      return historyMessages
-    }
-
-    // Always check for live messages if we have a session ID
-    if (liveSessionId) {
-      const liveMessages = sessionStore.getMessages(liveSessionId)
-      // If we have live messages or streaming text, combine them
-      if (liveMessages.length > 0 || streamingText.value) {
-        const newMessages = convertToDisplayMessages(liveMessages, streamingText.value)
-        
-        // Dedup by ID - history messages take priority
-        const historyIds = new Set(historyMessages.map(m => m.id))
-        const uniqueNewMessages = newMessages.filter(m => !historyIds.has(m.id))
-        
-        return [...historyMessages, ...uniqueNewMessages]
+      merged = historyMessages
+    } else {
+      // Always check for live messages if we have a session ID
+      if (liveSessionId) {
+        const liveMessages = sessionStore.getMessages(liveSessionId)
+        // If we have live messages or streaming text, combine them
+        if (liveMessages.length > 0 || streamingText.value) {
+          const newMessages = convertToDisplayMessages(liveMessages, streamingText.value)
+          
+          // Dedup by ID - history messages take priority
+          const historyIds = new Set(historyMessages.map(m => m.id))
+          const uniqueNewMessages = newMessages.filter(m => !historyIds.has(m.id))
+          
+          merged = [...historyMessages, ...uniqueNewMessages]
+        } else {
+          merged = historyMessages
+        }
+      } else {
+        merged = historyMessages
       }
     }
-
-    return historyMessages
+  } else {
+    // Live session only (new chat)
+    if (!liveSessionId) {
+      merged = []
+    } else {
+      const messages = sessionStore.getMessages(liveSessionId)
+      merged = convertToDisplayMessages(messages, streamingText.value)
+    }
   }
 
-  // Live session only (new chat)
-  if (!liveSessionId) {
-    return []
+  // Final logical deduplication pass (for the whole turn/response)
+  // This catches cases where the same tool call might have different IDs between history and live store
+  const finalMessages: DisplayChatMessage[] = []
+  const seenToolCalls = new Set<string>()
+
+  for (const msg of merged) {
+    if (msg.role === 'user') {
+      seenToolCalls.clear()
+      finalMessages.push(msg)
+      continue
+    }
+
+    if (msg.kind === 'tool_use') {
+      const tn = (msg.toolName || '').toLowerCase()
+      // Normalize name
+      let normName = tn
+      if (tn === 'read_file' || tn === 'read') normName = 'read'
+      if (tn === 'write_file' || tn === 'write') normName = 'write'
+      if (tn === 'glob_search' || tn === 'glob') normName = 'glob'
+      if (tn === 'grep_search' || tn === 'grep') normName = 'grep'
+
+      // Extract target (mimicking ChatV2MessageItem)
+      let target = ''
+      const input = msg.toolInput as any
+      if (typeof input === 'string') {
+        target = input.replace(/^\.\//, '')
+      } else if (input && typeof input === 'object') {
+        const val = input.file_path || input.path || input.filePath || input.filename || input.pattern || input.file || input.command || ''
+        target = typeof val === 'string' ? val.replace(/^\.\//, '') : JSON.stringify(val)
+      }
+
+      const key = `${normName}:${target}`
+      if (seenToolCalls.has(key)) continue
+      seenToolCalls.add(key)
+    }
+    
+    finalMessages.push(msg)
   }
 
-  const messages = sessionStore.getMessages(liveSessionId)
-  return convertToDisplayMessages(messages, streamingText.value)
+  return finalMessages
 })
 
 // Watch for errors and show toast

--- a/app/utils/chatMessageConverter.ts
+++ b/app/utils/chatMessageConverter.ts
@@ -7,6 +7,62 @@ import type {
 } from '~/types'
 
 /**
+ * Check if content appears to be a system message that should be filtered
+ */
+function isSystemMessage(content: string): boolean {
+  if (!content) return false
+
+  const systemPrefixes = [
+    '<command-name>',
+    '<command-message>',
+    '<command-args>',
+    '<local-command-stdout>',
+    '<system-reminder>',
+    'Caveat:',
+    'This session is being continued from a previous',
+    'Invalid API key',
+    '[Request interrupted',
+  ]
+
+  return systemPrefixes.some(prefix => content.trim().startsWith(prefix)) ||
+    content.includes('{"subtasks":')
+}
+
+/**
+ * Normalize tool names for deduplication
+ */
+function normalizeToolName(name: string): string {
+  const n = (name || '').toLowerCase()
+  if (n === 'read_file' || n === 'read') return 'read'
+  if (n === 'write_file' || n === 'write') return 'write'
+  if (n === 'glob_search' || n === 'glob') return 'glob'
+  if (n === 'tool_search' || n === 'toolsearch') return 'toolsearch'
+  if (n === 'grep_search' || n === 'grep') return 'grep'
+  return n
+}
+
+/**
+ * Extract target from tool input (mimicking ChatV2MessageItem.vue toolFileName)
+ */
+function getToolTarget(toolInput: any): string {
+  if (!toolInput) return ''
+  let input = toolInput
+  if (typeof input === 'string') {
+    try {
+      input = JSON.parse(input)
+    } catch (e) {
+      return input.replace(/^\.\//, '')
+    }
+  }
+
+  if (typeof input === 'object') {
+    const val = input.file_path || input.path || input.filePath || input.filename || input.pattern || input.file || input.command || ''
+    return typeof val === 'string' ? val.replace(/^\.\//, '') : JSON.stringify(val)
+  }
+  return ''
+}
+
+/**
  * Convert NormalizedMessage array to DisplayChatMessage array.
  * This handles:
  * - Filtering ephemeral messages (stream_delta, stream_end)
@@ -18,12 +74,17 @@ export function convertToDisplayMessages(
   messages: NormalizedMessage[],
   streamingText?: string
 ): DisplayChatMessage[] {
+  // Sort messages by timestamp first to ensure Turn-based deduplication works correctly
+  const sortedMessages = [...messages].sort((a, b) =>
+    new Date(a.timestamp || 0).getTime() - new Date(b.timestamp || 0).getTime()
+  )
+
   const displayMessages: DisplayChatMessage[] = []
   const toolResultsMap = new Map<string, any>()
   
   // Track AskUserQuestion tool calls that have a corresponding permission_request
   const askUserPermissionRequests = new Set<string>()
-  for (const msg of messages) {
+  for (const msg of sortedMessages) {
     if (msg.kind === 'permission_request') {
       const tn = (msg.toolName || '').toLowerCase()
       if (['askuserquestion', 'ask_user', 'askuser', 'ask_user_question', 'prompt', 'input_request'].includes(tn)) {
@@ -35,7 +96,7 @@ export function convertToDisplayMessages(
   }
 
   // First pass: collect tool results by toolId
-  for (const msg of messages) {
+  for (const msg of sortedMessages) {
     if (msg.kind === 'tool_result' && msg.toolId) {
       toolResultsMap.set(msg.toolId, {
         result: msg.toolResult,
@@ -46,7 +107,17 @@ export function convertToDisplayMessages(
   }
 
   // Second pass: convert messages to display format
-  for (const msg of messages) {
+  const seenToolCalls = new Set<string>()
+
+  for (const msg of sortedMessages) {
+    // Reset seen tools for each new user message (new interaction turn)
+    if (msg.role === 'user') {
+      // Only clear if NOT a system message
+      if (!isSystemMessage(msg.content || '')) {
+        seenToolCalls.clear()
+      }
+    }
+
     // Skip ephemeral messages
     if (msg.kind === 'stream_delta' || msg.kind === 'stream_end') {
       continue
@@ -81,6 +152,18 @@ export function convertToDisplayMessages(
     // Convert to display message
     const displayMsg = convertSingleMessage(msg, toolResultsMap)
     if (displayMsg) {
+      // Deduplication: skip if this is the same tool and target as a previous one in this turn
+      if (displayMsg.kind === 'tool_use') {
+        const toolName = normalizeToolName(displayMsg.toolName || '')
+        const target = getToolTarget(displayMsg.toolInput)
+        
+        const toolKey = `${toolName}:${target}`
+        if (seenToolCalls.has(toolKey)) {
+          continue
+        }
+        seenToolCalls.add(toolKey)
+      }
+
       displayMessages.push(displayMsg)
     }
   }

--- a/app/utils/claudeCodeMessageConverter.ts
+++ b/app/utils/claudeCodeMessageConverter.ts
@@ -80,15 +80,54 @@ function extractToolResultContent(content: string | Array<{ type: string; text?:
 }
 
 /**
+ * Normalize tool names for deduplication
+ */
+function normalizeToolName(name: string): string {
+  const n = (name || '').toLowerCase()
+  if (n === 'read_file' || n === 'read') return 'read'
+  if (n === 'write_file' || n === 'write') return 'write'
+  if (n === 'glob_search' || n === 'glob') return 'glob'
+  if (n === 'tool_search' || n === 'toolsearch') return 'toolsearch'
+  if (n === 'grep_search' || n === 'grep') return 'grep'
+  return n
+}
+
+/**
+ * Extract target from tool input (mimicking ChatV2MessageItem.vue toolFileName)
+ */
+function getToolTarget(toolInput: any): string {
+  if (!toolInput) return ''
+  let input = toolInput
+  if (typeof input === 'string') {
+    try {
+      input = JSON.parse(input)
+    } catch (e) {
+      return input.replace(/^\.\//, '')
+    }
+  }
+
+  if (typeof input === 'object') {
+    const val = input.file_path || input.path || input.filePath || input.filename || input.pattern || input.file || input.command || ''
+    return typeof val === 'string' ? val.replace(/^\.\//, '') : JSON.stringify(val)
+  }
+  return ''
+}
+
+/**
  * Convert Claude Code messages to DisplayChatMessage format
  */
 export function convertClaudeCodeMessages(messages: ClaudeCodeMessage[]): DisplayChatMessage[] {
+  // Sort messages by timestamp first to ensure Turn-based deduplication works correctly
+  const sortedMessages = [...messages].sort((a, b) =>
+    new Date(a.timestamp || 0).getTime() - new Date(b.timestamp || 0).getTime()
+  )
+
   const displayMessages: DisplayChatMessage[] = []
 
   // First pass: collect tool results by tool_use_id
   const toolResultsMap = new Map<string, { content: string; isError: boolean; toolUseResult?: any }>()
 
-  for (const msg of messages) {
+  for (const msg of sortedMessages) {
     if (msg.message?.content && Array.isArray(msg.message.content)) {
       for (const block of msg.message.content) {
         if (block.type === 'tool_result' && block.tool_use_id) {
@@ -104,7 +143,9 @@ export function convertClaudeCodeMessages(messages: ClaudeCodeMessage[]): Displa
   }
 
   // Second pass: convert messages
-  for (const msg of messages) {
+  const seenToolCalls = new Set<string>()
+
+  for (const msg of sortedMessages) {
     // Skip non-message entries
     if (msg.type === 'summary' || msg.type === 'file-history-snapshot') {
       continue
@@ -126,10 +167,13 @@ export function convertClaudeCodeMessages(messages: ClaudeCodeMessage[]): Displa
           .join('\n')
       }
 
-      // Skip system messages
+      // Skip system messages and DON'T clear seen tools for them
       if (isSystemMessage(textContent)) {
         continue
       }
+
+      // Real user message: reset seen tools for the new interaction turn
+      seenToolCalls.clear()
 
       if (textContent.trim()) {
         displayMessages.push({
@@ -178,6 +222,16 @@ export function convertClaudeCodeMessages(messages: ClaudeCodeMessage[]): Displa
           else if (block.type === 'tool_use' && block.name) {
             const toolResult = block.id ? toolResultsMap.get(block.id) : undefined
             
+            // Deduplication: skip if this is the same tool and target as a previous one in this turn
+            const toolName = normalizeToolName(block.name)
+            const target = getToolTarget(block.input)
+            
+            const toolKey = `${toolName}:${target}`
+            if (seenToolCalls.has(toolKey)) {
+              continue
+            }
+            seenToolCalls.add(toolKey)
+
             // Check if this is an AskUserQuestion
             const isAskUserQuestion = ['askuserquestion', 'ask_user', 'askuser', 'ask_user_question', 'prompt', 'input_request'].includes(block.name.toLowerCase())
             
@@ -232,20 +286,27 @@ export function convertClaudeCodeMessages(messages: ClaudeCodeMessage[]): Displa
 
     // Handle standalone tool entries (older format)
     else if (msg.toolName) {
-      displayMessages.push({
-        id: msg.uuid || `tool-${msg.timestamp}`,
-        role: 'assistant',
-        content: '',
-        timestamp: msg.timestamp,
-        kind: 'tool_use',
-        toolName: msg.toolName,
-        toolInput: msg.toolInput,
-        toolResult: msg.toolUseResult
-      })
+      const toolName = normalizeToolName(msg.toolName)
+      const target = getToolTarget(msg.toolInput)
+      
+      const toolKey = `${toolName}:${target}`
+      if (!seenToolCalls.has(toolKey)) {
+        seenToolCalls.add(toolKey)
+        displayMessages.push({
+          id: msg.uuid || `tool-${msg.timestamp}`,
+          role: 'assistant',
+          content: '',
+          timestamp: msg.timestamp,
+          kind: 'tool_use',
+          toolName: msg.toolName,
+          toolInput: msg.toolInput,
+          toolResult: msg.toolUseResult
+        })
+      }
     }
   }
 
-  // Sort by timestamp
+  // Sort by timestamp (final check for display order)
   displayMessages.sort((a, b) =>
     new Date(a.timestamp || 0).getTime() - new Date(b.timestamp || 0).getTime()
   )

--- a/bin/start.mjs
+++ b/bin/start.mjs
@@ -14,7 +14,7 @@ if (!existsSync(outputServer)) {
   execSync('npx nuxi build', { cwd: root, stdio: 'inherit' })
 }
 
-const port = process.env.PORT || 3000
+const port = process.env.PORT || 3030
 process.env.PORT = String(port)
 process.env.HOST = process.env.HOST || '0.0.0.0'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,16 @@ services:
     container_name: agents-ui
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "3030:3030"
     volumes:
       - ~/.claude:/root/.claude
     environment:
       - CLAUDE_DIR=/root/.claude
       - HOST=0.0.0.0
-      - PORT=3000
+      - PORT=3030
       - NODE_ENV=production
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:3030/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "build": "nuxt build",
-    "dev": "nuxt dev",
+    "dev": "nuxt dev --port 3030",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/server/utils/messageNormalizer.ts
+++ b/server/utils/messageNormalizer.ts
@@ -100,18 +100,24 @@ export function normalizeSDKMessage(
     // Other system subtypes (init, etc.) are silently ignored
   }
 
-  // Handle tool progress (Anthropic SDK tool execution)
-  if (sdkMessage.type === 'tool_progress') {
+  // Handle tool use (Anthropic SDK tool execution)
+  if (sdkMessage.type === 'tool_use' || sdkMessage.type === 'tool_progress') {
+    const isPermissionRequest = sdkMessage.is_permission_request || false
+
     messages.push({
-      kind: 'tool_use',
-      id: randomUUID(),
+      kind: isPermissionRequest ? 'permission_request' : 'tool_use',
+      id: sdkMessage.uuid || randomUUID(),
       sessionId,
       timestamp,
       toolName: sdkMessage.tool_name,
-      toolInput: undefined,
+      toolId: sdkMessage.tool_use_id,
+      toolInput: sdkMessage.tool_input,
+      requestId: sdkMessage.tool_use_id, // For pairing with response
+      content: isPermissionRequest ? `Allow ${sdkMessage.tool_name}?` : '',
       metadata: {
         elapsed: sdkMessage.elapsed_time_seconds,
-        status: 'running',
+        status: sdkMessage.type === 'tool_progress' ? 'running' : 'complete',
+        toolUseId: sdkMessage.tool_use_id,
       },
     })
   }


### PR DESCRIPTION
## Summary

- Standardize default port from 3000 to 3030 across all configurations (Dockerfile, docker-compose, scripts, docs)
- Fix duplicate tool call entries in chat history by adding turn-based deduplication logic to both message converters
- Improve SDK message normalization to handle `tool_use` events alongside `tool_progress` with permission request support

## Purpose

Two independent issues addressed together:
1. Port inconsistency — the app was using port 3000 in some configs and 3030 in others, causing confusion during development and Docker deployments.
2. Chat deduplication bug — when continuing from Claude Code history into a live session, tool calls (Read, Glob, Grep, etc.) were appearing twice because the history converter and live message store both emitted the same tool use events. The fix adds turn-scoped deduplication keyed on `normalizedToolName:target`.

## Features Changed

- **`package.json`**: `dev` script now passes `--port 3030` explicitly
- **`bin/start.mjs`**: Default `PORT` changed from 3000 to 3030
- **`Dockerfile` / `docker-compose.yml`**: `PORT`, `EXPOSE`, and healthcheck URL updated to 3030
- **`CLAUDE.md` / `CONTRIBUTING.md`**: Dev server URL updated to reflect correct port
- **`app/utils/chatMessageConverter.ts`**: Added `normalizeToolName` / `getToolTarget` helpers and per-turn `seenToolCalls` Set to deduplicate tool use blocks; messages now sorted by timestamp before processing
- **`app/utils/claudeCodeMessageConverter.ts`**: Same deduplication approach applied to Claude Code history messages; standalone tool entries also deduplicated
- **`app/components/cli/chatv2/ChatV2Interface.vue`**: Refactored `displayMessages` computed to run a final dedup pass over the merged history + live message array
- **`server/utils/messageNormalizer.ts`**: Handle `tool_use` SDK message type (in addition to `tool_progress`), expose `toolInput`, `toolId`, and `is_permission_request` flag

## Services Impacted

| Layer | Files |
|---|---|
| Server API | `server/utils/messageNormalizer.ts` |
| Frontend | `app/components/cli/chatv2/ChatV2Interface.vue`, `app/utils/chatMessageConverter.ts`, `app/utils/claudeCodeMessageConverter.ts` |
| Config / Infra | `Dockerfile`, `docker-compose.yml`, `bin/start.mjs`, `package.json` |
| Docs | `CLAUDE.md`, `CONTRIBUTING.md` |

## Tests Included

- [x] Start dev server and verify it listens on port 3030
- [x] Build and run Docker container — confirm healthcheck passes on port 3030
- [x] Open an existing Claude Code chat session and continue it — verify no duplicate tool calls appear in the message list
- [x] Start a fresh chat — verify tool calls render exactly once per invocation
- [x] Trigger a tool that requires permission — verify `permission_request` kind message renders correctly